### PR TITLE
feat: implement form submit button limit

### DIFF
--- a/packages/astro-reactive-form/Form.astro
+++ b/packages/astro-reactive-form/Form.astro
@@ -1,12 +1,13 @@
 ---
-import type { FormGroup } from './core';
+import type { FormControl, FormGroup } from './core';
 import FieldSet from './components/FieldSet.astro';
 
 export interface Props {
+	submitControl?: FormControl;
 	formGroups: FormGroup[];
 }
 
-const { formGroups } = Astro.props;
+const { submitControl, formGroups } = Astro.props;
 ---
 <form class="light">
 	{formGroups?.map((group) => <FieldSet group={group} />)}

--- a/packages/astro-reactive-form/Form.astro
+++ b/packages/astro-reactive-form/Form.astro
@@ -1,5 +1,6 @@
 ---
 import type { FormControl, FormGroup } from './core';
+import Field from './components/Field.astro';
 import FieldSet from './components/FieldSet.astro';
 
 export interface Props {
@@ -11,6 +12,7 @@ const { submitControl, formGroups } = Astro.props;
 ---
 <form class="light">
 	{formGroups?.map((group) => <FieldSet group={group} />)}
+	{submitControl && (<Field control={submitControl} />)}
 </form>
 
 <style>

--- a/packages/astro-reactive-form/core/form-group.ts
+++ b/packages/astro-reactive-form/core/form-group.ts
@@ -7,7 +7,9 @@ export class FormGroup {
 
 	constructor(controls: FormControlBase[], name: string = '') {
 		this.name = name;
-		this.controls = controls.map((control) => new FormControl(control));
+		this.controls = controls
+			.filter(control => control.type !== 'submit')
+			.map(control => new FormControl(control));
 	}
 
 	get(name: string): FormControl | undefined {


### PR DESCRIPTION
What is this PR about? (docs, fix, feature, style, devops, etc.)
-
This PR is to implement a feature to limit the form component to at most 1 submit control.

Related issue number: #23

Description of changes: 
-
I added a new optional `submitControl` prop in the `Form.astro` component and implemented a limit to the `FormGroup` constructor to not accept control type `submit`.

Tag a reviewer: @ayoayco 

Tasks:
- [x] I have ran the tests to make sure nothing is broken (see CONTRIBUTING.md)
- [x] I have mentioned the issue this PR is addressing
