### PR TITLE
Added form id property to fix getFormGroup

### DIFF
--- a/packages/astro-reactive-form/Form.astro
+++ b/packages/astro-reactive-form/Form.astro
@@ -12,9 +12,10 @@ export interface Props {
 const { submitControl, formGroups: form, theme } = Astro.props;
 
 const formTheme = theme ?? 'light';
+const formName = !Array.isArray(form) ? form?.name : null;
 ---
 
-<form class={formTheme}>
+<form id={formName} class={formTheme}>
 	{
 		Array.isArray(form)
 			? form?.map((group) => <FieldSet group={group} />)


### PR DESCRIPTION
type(scope): description
<!--
✨ Example PR titles:
    feat(form): implement new FormControl isValid state
    docs(library): update project CONTRIBUTING.md
-->

Fixes #86 

Description of changes: 
- Might be a makeshift fix -- I simply added a way to add id with the form name to the "form" element created by Form.astro if it is not an array -- if FormGroup is an array, each individual form is a fieldset and has an id with its name, and therefore can be targeted by getFormGroup.


Tag a reviewer: @ayoayco 

Tasks:
- [X] I have ran the tests to make sure nothing is broken (see CONTRIBUTING.md)
- [X] I have ran the the linter to make sure code is clean (see CONTRIBUTING.md)

<!-- THANK YOU FOR THE CONTRIBUTION! 🚀 -->