### PR TITLE
Copy to Clipboard Functionality Added on Landing Page

### DIFF
--- a/apps/landing-page/src/components/copynpm.astro
+++ b/apps/landing-page/src/components/copynpm.astro
@@ -4,8 +4,9 @@ import { Icon } from "astro-icon";
 
 <button
   class="copy-btn flex items-center w-4/5 mt-3 justify-center astro-md:w-1/2 astro-lg:w-[28%] astro-lg:mt-0 astro-lg:ml-3"
+  id="copy-command-button"
 >
-  <span>npm install @astro-reactive/form @astro-reactive/validator</span>
+  <span id="command">npm install @astro-reactive/form @astro-reactive/validator</span>
   <Icon name="mdi:content-copy" width="40px" height="40px" />
 </button>
 
@@ -32,3 +33,12 @@ import { Icon } from "astro-icon";
     background-color: #3f3f3f;
   }
 </style>
+
+<script>
+    const copyCommandButton = document.getElementById("copy-command-button");
+    const commandText = document.getElementById('command').innerText;
+    
+    copyCommandButton.addEventListener('click', () => {
+        navigator.clipboard.writeText(commandText);
+    });
+</script>


### PR DESCRIPTION
# feat(landing-page): add functionality of "copy to clipboard
<!--
☝️ Put your PR title up here!

✨ Example PR titles:
    feat(form): implement new FormControl isValid state
    fix(validator): correct the variable name typo causing errors
    refactor(common/types): improve TypeScript types
    style(landing-page): update the logo in the landing page app
    docs(project): update content project CONTRIBUTING.md
-->

Fixes #126 <!-- 👈🏻 Put the issue number here! -->

Description of changes: <!-- 👇🏻 List the changes done! -->
- Added id in button and span tag to get the element by ID.
- Created a vanilla JavaScript function and added it to as event listener on click of button to get the `innerText` of `span tag` using its ID.

Tag a reviewer: @ayoayco 

Tasks:
- [x] I have ran the build command to make sure apps are working: `npm run build`
- [x] I have ran the tests to make sure nothing is broken: `npm run test`
- [x] I have ran the linter to make sure code is clean: `npm run lint`
- [x] I have reviewed my own code to remove changes that are not needed

<!-- THANK YOU FOR THE CONTRIBUTION! 🚀 -->