### PR TITLE
feat(form): add Dropdown control

### DIFF
--- a/apps/demo/src/pages/index.astro
+++ b/apps/demo/src/pages/index.astro
@@ -39,6 +39,13 @@ const form = new FormGroup([
       { label: "Disagree", value: "no" },
     ],
   },
+  {
+    name: "size",
+    label: "Shirt size",
+    type: "dropdown",
+    placeholder: "-- Please select --",
+    value: ["S", "M", "L", "XL", "XXL"],
+  },
 ]);
 
 form.name = "Simple Form";

--- a/apps/demo/src/pages/index.astro
+++ b/apps/demo/src/pages/index.astro
@@ -41,10 +41,10 @@ const form = new FormGroup([
   },
   {
     name: "size",
-    label: "Shirt size",
+    label: "Size",
     type: "dropdown",
-    placeholder: "-- Please select --",
-    value: ["S", "M", "L", "XL", "XXL"],
+    options: ["S", "M", "L", "XL", "XXL"],
+    placeholder: "-- Please choose an option --",
   },
 ]);
 

--- a/packages/common/types/control.types.ts
+++ b/packages/common/types/control.types.ts
@@ -23,7 +23,8 @@ export type ControlType =
   | "tel"
   | "time"
   | "url"
-  | "week";
+  | "week"
+  | "dropdown";
 
 export interface ControlBase {
   name: string;
@@ -51,6 +52,17 @@ export interface Radio extends Omit<ControlBase, "value"> {
 export interface RadioOption {
   label: string;
   value: string;
+}
+
+export interface Dropdown extends Omit<ControlBase, "value"> {
+  type: "dropdown";
+  value: string[] | DropdownOption[];
+}
+
+export interface DropdownOption {
+  label: string;
+  value: string;
+  checked?: boolean;
 }
 
 export interface Submit extends ControlBase {

--- a/packages/common/types/control.types.ts
+++ b/packages/common/types/control.types.ts
@@ -56,13 +56,13 @@ export interface RadioOption {
 
 export interface Dropdown extends Omit<ControlBase, "value"> {
   type: "dropdown";
-  value: string[] | DropdownOption[];
+  value?: string;
+  options: string[] | DropdownOption[];
 }
 
 export interface DropdownOption {
   label: string;
   value: string;
-  checked?: boolean;
 }
 
 export interface Submit extends ControlBase {

--- a/packages/common/types/control.types.ts
+++ b/packages/common/types/control.types.ts
@@ -2,7 +2,7 @@
  * `ControlType` determines the type of form control
  * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types
  */
-export type ControlType =
+export type InputType =
   | "text"
   | "checkbox"
   | "radio"
@@ -23,8 +23,9 @@ export type ControlType =
   | "tel"
   | "time"
   | "url"
-  | "week"
-  | "dropdown";
+  | "week";
+
+export type ControlType = InputType | "dropdown";
 
 export interface ControlBase {
   name: string;

--- a/packages/common/types/control.types.ts
+++ b/packages/common/types/control.types.ts
@@ -36,7 +36,7 @@ export interface ControlBase {
   labelPosition?: "right" | "left";
   placeholder?: string;
   validators?: string[]; // TODO: implement validator type
-  options?: string[] | RadioOption[]; // prevent build failed
+  options?: string[] | ControlOption[];
 }
 
 export interface Checkbox extends ControlBase {
@@ -47,21 +47,16 @@ export interface Checkbox extends ControlBase {
 export interface Radio extends Omit<ControlBase, "value"> {
   type: "radio";
   value?: string;
-  options: string[] | RadioOption[];
-}
-
-export interface RadioOption {
-  label: string;
-  value: string;
+  options: string[] | ControlOption[];
 }
 
 export interface Dropdown extends Omit<ControlBase, "value"> {
   type: "dropdown";
   value?: string;
-  options: string[] | DropdownOption[];
+  options: string[] | ControlOption[];
 }
 
-export interface DropdownOption {
+export interface ControlOption {
   label: string;
   value: string;
 }

--- a/packages/form/components/Field.astro
+++ b/packages/form/components/Field.astro
@@ -4,7 +4,7 @@
  */
 import type { Radio, Dropdown } from 'common/types';
 import type { FormControl } from '../core/form-control';
-import DropdownGroup from './controls/Dropdown.astro';
+import DropdownControl from './controls/Dropdown.astro';
 import Input from './controls/Input.astro';
 import RadioGroup from './controls/RadioGroup.astro';
 import Errors from './Errors.astro';
@@ -28,7 +28,7 @@ const hasErrors: boolean | null = !!control.errors?.length;
 				<RadioGroup control={control as Radio} />
 			) :
 			control.type === 'dropdown' ? (
-				<DropdownGroup control={control as Dropdown} />
+				<DropdownControl control={control as Dropdown} />
 			) : (
 				<Input control={control} />
 			)

--- a/packages/form/components/Field.astro
+++ b/packages/form/components/Field.astro
@@ -2,8 +2,9 @@
 /**
  * DEFAULT CONTROL COMPONENT
  */
-import type { Radio } from '@astro-reactive/common';
+import type { Radio, Dropdown } from 'common/types';
 import type { FormControl } from '../core/form-control';
+import DropdownGroup from './controls/Dropdown.astro';
 import Input from './controls/Input.astro';
 import RadioGroup from './controls/RadioGroup.astro';
 import Errors from './Errors.astro';
@@ -25,6 +26,9 @@ const hasErrors: boolean | null = !!control.errors?.length;
 		{
 			control.type === 'radio' ? (
 				<RadioGroup control={control as Radio} />
+			) :
+			control.type === 'dropdown' ? (
+				<DropdownGroup control={control as Dropdown} />
 			) : (
 				<Input control={control} />
 			)

--- a/packages/form/components/Field.astro
+++ b/packages/form/components/Field.astro
@@ -2,7 +2,7 @@
 /**
  * DEFAULT CONTROL COMPONENT
  */
-import type { Radio, Dropdown } from 'common/types';
+import type { Radio, Dropdown } from '@astro-reactive/common';
 import type { FormControl } from '../core/form-control';
 import DropdownControl from './controls/Dropdown.astro';
 import Input from './controls/Input.astro';

--- a/packages/form/components/controls/Dropdown.astro
+++ b/packages/form/components/controls/Dropdown.astro
@@ -2,7 +2,7 @@
 /**
  * DROPDOWN COMPONENT
  */
- import type { Dropdown } from 'common/types';
+import type { Dropdown, DropdownOption } from 'common/types';
 
 export interface Props {
 	control: Dropdown;
@@ -10,7 +10,7 @@ export interface Props {
 
 const { control } = Astro.props;
 
-const options = control.options.map((option) => {
+const options = control.options.map((option: string | DropdownOption) => {
 	if (typeof option === 'string') {
 		return {
 			label: option,
@@ -30,7 +30,7 @@ const options = control.options.map((option) => {
 	)
 }
 {	
-	options.map((option) => (
+	options.map((option: DropdownOption) => (
         <option
 			value={option.value} 
 			selected={option.value === control.value}

--- a/packages/form/components/controls/Dropdown.astro
+++ b/packages/form/components/controls/Dropdown.astro
@@ -2,7 +2,7 @@
 /**
  * DROPDOWN COMPONENT
  */
-import type { Dropdown, DropdownOption } from '@astro-reactive/common';
+import type { Dropdown, ControlOption } from '@astro-reactive/common';
 
 export interface Props {
 	control: Dropdown;
@@ -10,7 +10,7 @@ export interface Props {
 
 const { control } = Astro.props;
 
-const options = control.options.map((option: string | DropdownOption) => {
+const options = control.options.map((option: string | ControlOption) => {
 	if (typeof option === 'string') {
 		return {
 			label: option,
@@ -30,7 +30,7 @@ const options = control.options.map((option: string | DropdownOption) => {
 	)
 }
 {	
-	options.map((option: DropdownOption) => (
+	options.map((option: ControlOption) => (
         <option
 			value={option.value} 
 			selected={option.value === control.value}

--- a/packages/form/components/controls/Dropdown.astro
+++ b/packages/form/components/controls/Dropdown.astro
@@ -1,16 +1,16 @@
 ---
 /**
- * RADIO GROUP COMPONENT
+ * DROPDOWN COMPONENT
  */
- import type { Radio } from 'common/types';
+ import type { Dropdown } from 'common/types';
 
 export interface Props {
-	control: Radio;
+	control: Dropdown;
 }
 
 const { control } = Astro.props;
 
-const options = control.value.map((option) => {
+const options = control.options.map((option) => {
 	if (typeof option === 'string') {
 		return {
 			label: option,
@@ -21,17 +21,20 @@ const options = control.value.map((option) => {
 });
 ---
 
-<select>
+<select name={control.name} id={control.name}>
 {
 	control?.placeholder && (
-		<option value="" disabled>
+		<option value="" disabled selected={!control?.value}>
 			{control.placeholder}
         </option>
 	)
 }
 {	
 	options.map((option) => (
-        <option value={option.value} selected={option.checked}>
+        <option
+			value={option.value} 
+			selected={option.value === control.value}
+		>
 			{option.label}
         </option>
 	))

--- a/packages/form/components/controls/Dropdown.astro
+++ b/packages/form/components/controls/Dropdown.astro
@@ -1,0 +1,39 @@
+---
+/**
+ * RADIO GROUP COMPONENT
+ */
+ import type { Radio } from 'common/types';
+
+export interface Props {
+	control: Radio;
+}
+
+const { control } = Astro.props;
+
+const options = control.value.map((option) => {
+	if (typeof option === 'string') {
+		return {
+			label: option,
+			value: option,
+		};
+	}
+	return option;
+});
+---
+
+<select>
+{
+	control?.placeholder && (
+		<option value="" disabled>
+			{control.placeholder}
+        </option>
+	)
+}
+{	
+	options.map((option) => (
+        <option value={option.value} selected={option.checked}>
+			{option.label}
+        </option>
+	))
+}
+</select>

--- a/packages/form/components/controls/Dropdown.astro
+++ b/packages/form/components/controls/Dropdown.astro
@@ -2,7 +2,7 @@
 /**
  * DROPDOWN COMPONENT
  */
-import type { Dropdown, DropdownOption } from 'common/types';
+import type { Dropdown, DropdownOption } from '@astro-reactive/common';
 
 export interface Props {
 	control: Dropdown;

--- a/packages/form/components/controls/Input.astro
+++ b/packages/form/components/controls/Input.astro
@@ -2,6 +2,7 @@
 /**
  * DEFAULT INPUT COMPONENT
  */
+import type { InputType } from 'common/types';
 import type { FormControl } from '../../core/form-control';
 
 export interface Props {
@@ -29,7 +30,7 @@ const validatorAttributes: Record<string, string> = validators?.reduce((prev, va
 <input
 	name={control.name}
 	id={control.name}
-	type={control.type}
+	type={control.type as InputType}
 	value={control.value?.toString()}
 	checked={control.value === 'checked'}
 	placeholder={control.placeholder}

--- a/packages/form/components/controls/Input.astro
+++ b/packages/form/components/controls/Input.astro
@@ -2,7 +2,7 @@
 /**
  * DEFAULT INPUT COMPONENT
  */
-import type { InputType } from 'common/types';
+import type { InputType } from '@astro-reactive/common';
 import type { FormControl } from '../../core/form-control';
 
 export interface Props {

--- a/packages/form/components/controls/RadioGroup.astro
+++ b/packages/form/components/controls/RadioGroup.astro
@@ -2,7 +2,7 @@
 /**
  * RADIO GROUP COMPONENT
  */
-import type { Radio } from '@astro-reactive/common';
+import type { Radio, ControlOption } from '@astro-reactive/common';
 
 export interface Props {
 	control: Radio;
@@ -10,7 +10,7 @@ export interface Props {
 
 const { control } = Astro.props;
 
-const options = control.options.map((option) => {
+const options = control.options.map((option: string | ControlOption) => {
 	if (typeof option === 'string') {
 		return {
 			label: option,
@@ -22,7 +22,7 @@ const options = control.options.map((option) => {
 ---
 
 {
-	options.map((option) => (
+	options.map((option: ControlOption) => (
 		<div class="radio-option">
 			<input
 				type="radio"

--- a/packages/form/core/form-control.ts
+++ b/packages/form/core/form-control.ts
@@ -5,16 +5,18 @@ import type {
 	ControlType,
 	Radio,
 	RadioOption,
+	Dropdown,
+	DropdownOption,
 	Submit,
 	ValidationError,
 } from '@astro-reactive/common';
 
-export type ControlConfig = ControlBase | Checkbox | Radio | Submit | Button;
+export type ControlConfig = ControlBase | Checkbox | Radio | Submit | Button | Dropdown;
 
 export class FormControl {
 	private _name = '';
 	private _type: ControlType = 'text';
-	private _value?: string | number | null | string[] | RadioOption[];
+	private _value?: string | number | null | string[] | RadioOption[] | DropdownOption[];
 	private _label = '';
 	private _labelPosition?: 'right' | 'left' = 'left';
 	private _isValid = true;

--- a/packages/form/core/form-control.ts
+++ b/packages/form/core/form-control.ts
@@ -4,9 +4,8 @@ import type {
 	ControlBase,
 	ControlType,
 	Radio,
-	RadioOption,
 	Dropdown,
-	DropdownOption,
+	ControlOption,
 	Submit,
 	ValidationError,
 } from '@astro-reactive/common';
@@ -16,7 +15,7 @@ export type ControlConfig = ControlBase | Checkbox | Radio | Submit | Button | D
 export class FormControl {
 	private _name = '';
 	private _type: ControlType = 'text';
-	private _value?: string | number | null | string[] | RadioOption[] | DropdownOption[];
+	private _value?: string | number | null | string[] | ControlOption[];
 	private _label = '';
 	private _labelPosition?: 'right' | 'left' = 'left';
 	private _isValid = true;
@@ -24,7 +23,7 @@ export class FormControl {
 	private _placeholder: string | null = null;
 	private _validators: string[] = [];
 	private _errors: ValidationError[] = [];
-	private _options: string[] | RadioOption[] = [];
+	private _options: string[] | ControlOption[] = [];
 
 	private validate: (value: string, validators: string[]) => ValidationError[] = (
 		value: string,

--- a/packages/form/test/Dropdown.astro.test.js
+++ b/packages/form/test/Dropdown.astro.test.js
@@ -33,7 +33,7 @@ describe('Dropdown.astro test', () => {
 		expect(matches.length).to.equal(expectedOptions);
 	});
 
-	it('Should render all dropdown DropdownOption[] options', async () => {
+	it('Should render all dropdown ControlOption[] options', async () => {
 		// arrange
 		const expectedOptions = 3;
 		const element = /<option/g;
@@ -116,7 +116,7 @@ describe('Dropdown.astro test', () => {
 		expect(actualResult).to.contain(expectedResult);
 	});
 
-	it('Should select a selected dropdown option from DropdownOption[] correctly', async () => {
+	it('Should select a selected dropdown option from ControlOption[] correctly', async () => {
 		const expectedResult = '<optionvalue="three"selected="true">';
 		const props = {
 			control: {

--- a/packages/form/test/Dropdown.astro.test.js
+++ b/packages/form/test/Dropdown.astro.test.js
@@ -1,0 +1,153 @@
+import { expect } from 'chai';
+import { describe, beforeEach, it } from 'mocha';
+import { getComponentOutput } from 'astro-component-tester';
+import { cleanString } from './utils/index.js';
+
+describe('Dropdown.astro test', () => {
+	let component;
+
+	beforeEach(() => {
+		component = undefined;
+	});
+
+	it('Should render all dropdown string[] options', async () => {
+		// arrange
+		const expectedOptions = 3;
+		const element = /<option/g;
+		const props = {
+			control: {
+				label: 'FAKE LABEL',
+				name: 'FAKE NAME',
+				type: 'dropdown',
+				options: ['one', 'two', 'three'],
+			},
+			showValidationHints: true,
+		};
+
+		// act
+		component = await getComponentOutput('./components/controls/Dropdown.astro', props);
+		const actualResult = cleanString(component.html);
+		const matches = actualResult.match(element) || [];
+
+		// assert
+		expect(matches.length).to.equal(expectedOptions);
+	});
+
+	it('Should render all dropdown DropdownOption[] options', async () => {
+		// arrange
+		const expectedOptions = 3;
+		const element = /<option/g;
+		const props = {
+			control: {
+				label: 'FAKE LABEL',
+				name: 'FAKE NAME',
+				type: 'dropdown',
+				options: [
+					{
+						label: 'one',
+						value: 'one',
+					},
+					{
+						label: 'two',
+						value: 'two',
+					},
+					{
+						label: 'three',
+						value: 'three',
+					},
+				],
+			},
+			showValidationHints: true,
+		};
+
+		// act
+		component = await getComponentOutput('./components/controls/Dropdown.astro', props);
+		const actualResult = cleanString(component.html);
+		const matches = actualResult.match(element) || [];
+
+		// assert
+		expect(matches.length).to.equal(expectedOptions);
+	});
+
+	it('Should render a dropdown with placeholder', async () => {
+		// arrange
+		const expectedResult = '<optionvalue=""disabledselected="true">TEST</option>';
+		const expectedOptions = 4;
+		const element = /<option/g;
+		const props = {
+			control: {
+				label: 'FAKE LABEL',
+				name: 'FAKE NAME',
+				type: 'dropdown',
+				placeholder: 'TEST',
+				options: ['one', 'two', 'three'],
+			},
+			showValidationHints: true,
+		};
+
+		// act
+		component = await getComponentOutput('./components/controls/Dropdown.astro', props);
+		const actualResult = cleanString(component.html);
+		const matches = actualResult.match(element) || [];
+
+		console.log(actualResult);
+		// assert
+		expect(matches.length).to.equal(expectedOptions);
+		expect(actualResult).to.contain(expectedResult);
+	});
+
+	it('Should select a selected dropdown option from string[] correctly', async () => {
+		const expectedResult = '<optionvalue="two"selected="true">';
+		const props = {
+			control: {
+				label: 'FAKE LABEL',
+				name: 'FAKE NAME',
+				type: 'dropdown',
+				value: 'two',
+				options: ['one', 'two', 'three'],
+			},
+			showValidationHints: true,
+		};
+
+		// act
+		component = await getComponentOutput('./components/controls/Dropdown.astro', props);
+		const actualResult = cleanString(component.html);
+
+		// assert
+		expect(actualResult).to.contain(expectedResult);
+	});
+
+	it('Should select a selected dropdown option from DropdownOption[] correctly', async () => {
+		const expectedResult = '<optionvalue="three"selected="true">';
+		const props = {
+			control: {
+				label: 'FAKE LABEL',
+				name: 'FAKE NAME',
+				type: 'dropdown',
+				value: 'three',
+				options: [
+					{
+						value: 'one',
+						label: '1',
+					},
+					{
+						value: 'two',
+						label: '2',
+					},
+					{
+						value: 'three',
+						label: '3',
+					},
+				],
+			},
+			showValidationHints: true,
+		};
+
+		// act
+		component = await getComponentOutput('./components/controls/Dropdown.astro', props);
+		const actualResult = cleanString(component.html);
+
+		// assert
+		expect(actualResult).to.contain(expectedResult);
+	});
+});

--- a/packages/form/test/Dropdown.astro.test.js
+++ b/packages/form/test/Dropdown.astro.test.js
@@ -90,7 +90,6 @@ describe('Dropdown.astro test', () => {
 		const actualResult = cleanString(component.html);
 		const matches = actualResult.match(element) || [];
 
-		console.log(actualResult);
 		// assert
 		expect(matches.length).to.equal(expectedOptions);
 		expect(actualResult).to.contain(expectedResult);

--- a/packages/form/test/RadioGroup.astro.test.js
+++ b/packages/form/test/RadioGroup.astro.test.js
@@ -54,7 +54,7 @@ describe('RadioGroup.astro test', () => {
 		expect(actualResult).to.contain(expectedResult);
 	});
 
-	it('Should render a checked radio option from RadioOption[] correctly', async () => {
+	it('Should render a checked radio option from ControlOption[] correctly', async () => {
 		const expectedResult = '<inputtype="radio"name="FAKENAME"value="three"checked="true">';
 		const props = {
 			control: {


### PR DESCRIPTION
feat(form): Add Dropdown Control

Fixes #143 

Description of changes:
- Implement a `Dropdown.astro` control.
- Add `Dropdown` and `DropdownOption` type. 
These types have attributes like `Radio` and `RadioOption` types but I created it for use in case the dropdown has different attributes than that in the future.
- Include tests on a `Dropdown` control.

Tag a reviewer: @ayoayco 

Tasks:
- [x] I have ran the build command to make sure apps are working: `npm run build`
- [x] I have ran the tests to make sure nothing is broken: `npm run test`
- [x] I have ran the linter to make sure code is clean: `npm run lint`
- [x] I have reviewed my own code to remove changes that are not needed

<!-- THANK YOU FOR THE CONTRIBUTION! 🚀 -->