### PR TITLE
fix(form): asterisks on required field in `Label.astro`

### DIFF
--- a/packages/form/components/Label.astro
+++ b/packages/form/components/Label.astro
@@ -14,23 +14,26 @@ const { validators = [] } = control;
 const isRequired: boolean = showValidationHints && validators.includes('validator-required');
 ---
 
-	{
-		control.label && control.labelPosition === 'left' && (
-			<label for={control.name}>
-				{isRequired && <span>*</span>}
-				{control.label}
-			</label>
-		)
+{
+	control.label && control.labelPosition === 'left' && (
+		<label for={control.name} data-validation-required={isRequired ? "true" : null}>
+			{control.label}
+		</label>
+	)
+}
+
+<slot />
+
+{
+	control.label && control.labelPosition === 'right' && (
+		<label for={control.name} data-validation-required={isRequired ? "true" : null}>
+			{control.label}
+		</label>
+	)
+}
+
+<style>
+	label[data-validation-required="true"]::before {
+		content: "*";
 	}
-
-	<slot />
-
-	{
-		control.label && control.labelPosition === 'right' && (
-			<label for={control.name}>
-				{isRequired && <span>*</span>}
-				{control.label}
-			</label>
-		)
-	}
-
+</style>


### PR DESCRIPTION
fix(form): asterisks on required field in `Label.astro`

Fixes #104 

This approach is same as a recently fix PR on this issue.

Description of changes:
- Change the way to display an asterisk from text to ::before pseudo-classes

Tag a reviewer: @ayoayco 

Tasks:
- [x] I have ran the build command to make sure apps are working: `npm run build`
- [x] I have ran the tests to make sure nothing is broken: `npm run test`
- [x] I have ran the linter to make sure code is clean: `npm run lint`
- [x] I have reviewed my own code to remove changes that are not needed