### PR TITLE
feat(form): implement TextArea control

### DIFF
--- a/apps/demo/src/pages/index.astro
+++ b/apps/demo/src/pages/index.astro
@@ -46,6 +46,12 @@ const form = new FormGroup([
     options: ["S", "M", "L", "XL", "XXL"],
     placeholder: "-- Please choose an option --",
   },
+  {
+    name: "comment",
+    label: "Feedback",
+    type: "textarea",
+    value: "Nice!"
+  },
 ]);
 
 form.name = "Simple Form";

--- a/packages/common/types/control.types.ts
+++ b/packages/common/types/control.types.ts
@@ -25,7 +25,7 @@ export type InputType =
   | "url"
   | "week";
 
-export type ControlType = InputType | "dropdown";
+export type ControlType = InputType | "dropdown" | "textarea";
 
 export interface ControlBase {
   name: string;
@@ -37,6 +37,8 @@ export interface ControlBase {
   placeholder?: string;
   validators?: string[]; // TODO: implement validator type
   options?: string[] | ControlOption[];
+  rows?: number;
+  cols?: number;
 }
 
 export interface Checkbox extends ControlBase {
@@ -54,6 +56,13 @@ export interface Dropdown extends Omit<ControlBase, "value"> {
   type: "dropdown";
   value?: string;
   options: string[] | ControlOption[];
+}
+
+export interface TextArea extends ControlBase {
+  type: "textarea";
+  value?: string;
+  rows?: number;
+  cols?: number;
 }
 
 export interface ControlOption {

--- a/packages/common/types/control.types.ts
+++ b/packages/common/types/control.types.ts
@@ -37,8 +37,10 @@ export interface ControlBase {
   placeholder?: string;
   validators?: string[]; // TODO: implement validator type
   options?: string[] | ControlOption[];
-  rows?: number;
-  cols?: number;
+}
+
+export interface TextInput extends ControlBase {
+  type: Exclude<InputType, "checkbox" | "radio" | "submit" | "button">;
 }
 
 export interface Checkbox extends ControlBase {

--- a/packages/form/components/Field.astro
+++ b/packages/form/components/Field.astro
@@ -33,7 +33,7 @@ const hasErrors: boolean | null = !!control.errors?.length;
 				<DropdownControl control={control as Dropdown} readOnly={readOnly} />
 			) :
 			control.type === 'textarea' ? (
-				<TextAreaControl control={control as TextArea} />
+				<TextAreaControl control={control as TextArea} readOnly={readOnly} />
 			) : (
 				<Input control={control} readOnly={readOnly} />
 			)

--- a/packages/form/components/Field.astro
+++ b/packages/form/components/Field.astro
@@ -2,9 +2,10 @@
 /**
  * DEFAULT CONTROL COMPONENT
  */
-import type { Radio, Dropdown } from '@astro-reactive/common';
+import type { Radio, Dropdown, TextArea } from '@astro-reactive/common';
 import type { FormControl } from '../core/form-control';
 import DropdownControl from './controls/Dropdown.astro';
+import TextAreaControl from './controls/TextArea.astro';
 import Input from './controls/Input.astro';
 import RadioGroup from './controls/RadioGroup.astro';
 import Errors from './Errors.astro';
@@ -29,6 +30,9 @@ const hasErrors: boolean | null = !!control.errors?.length;
 			) :
 			control.type === 'dropdown' ? (
 				<DropdownControl control={control as Dropdown} />
+			) :
+			control.type === 'textarea' ? (
+				<TextAreaControl control={control as TextArea} />
 			) : (
 				<Input control={control} />
 			)

--- a/packages/form/components/Field.astro
+++ b/packages/form/components/Field.astro
@@ -2,7 +2,7 @@
 /**
  * DEFAULT CONTROL COMPONENT
  */
-import type { Radio, Dropdown, TextArea } from '@astro-reactive/common';
+import type { Radio, Dropdown } from '@astro-reactive/common';
 import type { FormControl } from '../core/form-control';
 import DropdownControl from './controls/Dropdown.astro';
 import TextAreaControl from './controls/TextArea.astro';
@@ -32,7 +32,7 @@ const hasErrors: boolean | null = !!control.errors?.length;
 				<DropdownControl control={control as Dropdown} />
 			) :
 			control.type === 'textarea' ? (
-				<TextAreaControl control={control as TextArea} />
+				<TextAreaControl control={control} />
 			) : (
 				<Input control={control} />
 			)

--- a/packages/form/components/Field.astro
+++ b/packages/form/components/Field.astro
@@ -2,7 +2,7 @@
 /**
  * DEFAULT CONTROL COMPONENT
  */
-import type { Radio, Dropdown } from '@astro-reactive/common';
+import type { Radio, Dropdown, TextArea } from '@astro-reactive/common';
 import type { FormControl } from '../core/form-control';
 import DropdownControl from './controls/Dropdown.astro';
 import TextAreaControl from './controls/TextArea.astro';
@@ -32,7 +32,7 @@ const hasErrors: boolean | null = !!control.errors?.length;
 				<DropdownControl control={control as Dropdown} />
 			) :
 			control.type === 'textarea' ? (
-				<TextAreaControl control={control} />
+				<TextAreaControl control={control as TextArea} />
 			) : (
 				<Input control={control} />
 			)

--- a/packages/form/components/controls/TextArea.astro
+++ b/packages/form/components/controls/TextArea.astro
@@ -2,10 +2,10 @@
 /**
  * TEXT AREA COMPONENT
  */
-import type { TextArea } from '@astro-reactive/common';
+import type { FormControl } from '../../core/form-control';
 
 export interface Props {
-	control: TextArea;
+	control: FormControl;
 }
 
 const { control } = Astro.props;
@@ -30,7 +30,6 @@ const validatorAttributes: Record<string, string> = validators?.reduce((prev, va
     name={control.name}
     id={control.name}
     placeholder={control?.placeholder}
-    value={control?.value}
     rows={control?.rows ?? 3}
     cols={control?.cols ?? 21}
     data-label={control?.label}

--- a/packages/form/components/controls/TextArea.astro
+++ b/packages/form/components/controls/TextArea.astro
@@ -1,0 +1,25 @@
+---
+/**
+ * TEXT AREA COMPONENT
+ */
+import type { TextArea } from '@astro-reactive/common';
+
+export interface Props {
+	control: TextArea;
+}
+
+const { control } = Astro.props;
+---
+
+<textarea
+    name={control.name}
+    id={control.name}
+    placeholder={control?.placeholder}
+    value={control?.value}
+    rows={control?.rows ?? 3}
+    cols={control?.cols ?? 21}
+    data-label={control?.label}
+    data-label-position={control?.labelPosition}
+>
+{ control.value }
+</textarea>

--- a/packages/form/components/controls/TextArea.astro
+++ b/packages/form/components/controls/TextArea.astro
@@ -2,17 +2,15 @@
 /**
  * TEXT AREA COMPONENT
  */
-import type { FormControl } from '../../core/form-control';
+import type { TextArea } from '@astro-reactive/common';
 
 export interface Props {
-	control: FormControl;
+	control: TextArea;
 }
 
 const { control } = Astro.props;
 
 const { validators = [] } = control;
-
-const hasErrors: boolean = !!control.errors?.length;
 
 const validatorAttributes: Record<string, string> = validators?.reduce((prev, validator) => {
 	const split: string[] = validator.split(':');
@@ -34,7 +32,6 @@ const validatorAttributes: Record<string, string> = validators?.reduce((prev, va
     cols={control?.cols ?? 21}
     data-label={control?.label}
     data-label-position={control?.labelPosition}
-    data-validator-haserrors={hasErrors.toString()}
     {...validatorAttributes}
 >
 { control.value }

--- a/packages/form/components/controls/TextArea.astro
+++ b/packages/form/components/controls/TextArea.astro
@@ -26,15 +26,15 @@ const validatorAttributes: Record<string, string> = validators?.reduce((prev, va
 ---
 
 <textarea
-    name={control.name}
-    id={control.name}
-    placeholder={control?.placeholder}
-    rows={control?.rows ?? 3}
-    cols={control?.cols ?? 21}
-    data-label={control?.label}
-    data-label-position={control?.labelPosition}
+	name={control.name}
+	id={control.name}
+	placeholder={control?.placeholder}
+	rows={control?.rows ?? 3}
+	cols={control?.cols ?? 21}
+	data-label={control?.label}
+	data-label-position={control?.labelPosition}
 	readonly={readOnly || null}
-    {...validatorAttributes}
+	{...validatorAttributes}
 >
 { control.value }
 </textarea>

--- a/packages/form/components/controls/TextArea.astro
+++ b/packages/form/components/controls/TextArea.astro
@@ -9,6 +9,21 @@ export interface Props {
 }
 
 const { control } = Astro.props;
+
+const { validators = [] } = control;
+
+const hasErrors: boolean = !!control.errors?.length;
+
+const validatorAttributes: Record<string, string> = validators?.reduce((prev, validator) => {
+	const split: string[] = validator.split(':');
+	const label: string = `data-${split[0]}` || 'invalid';
+	const value: string | null = split.length > 1 ? split[1] ?? null : 'true';
+
+	return {
+		...prev,
+		[label]: value,
+	};
+}, {});
 ---
 
 <textarea
@@ -20,6 +35,8 @@ const { control } = Astro.props;
     cols={control?.cols ?? 21}
     data-label={control?.label}
     data-label-position={control?.labelPosition}
+	data-validator-haserrors={hasErrors.toString()}
+	{...validatorAttributes}
 >
 { control.value }
 </textarea>

--- a/packages/form/components/controls/TextArea.astro
+++ b/packages/form/components/controls/TextArea.astro
@@ -6,9 +6,10 @@ import type { TextArea } from '@astro-reactive/common';
 
 export interface Props {
 	control: TextArea;
+	readOnly?: boolean;
 }
 
-const { control } = Astro.props;
+const { control, readOnly = false } = Astro.props;
 
 const { validators = [] } = control;
 
@@ -32,6 +33,7 @@ const validatorAttributes: Record<string, string> = validators?.reduce((prev, va
     cols={control?.cols ?? 21}
     data-label={control?.label}
     data-label-position={control?.labelPosition}
+	readonly={readOnly || null}
     {...validatorAttributes}
 >
 { control.value }

--- a/packages/form/components/controls/TextArea.astro
+++ b/packages/form/components/controls/TextArea.astro
@@ -34,8 +34,8 @@ const validatorAttributes: Record<string, string> = validators?.reduce((prev, va
     cols={control?.cols ?? 21}
     data-label={control?.label}
     data-label-position={control?.labelPosition}
-	data-validator-haserrors={hasErrors.toString()}
-	{...validatorAttributes}
+    data-validator-haserrors={hasErrors.toString()}
+    {...validatorAttributes}
 >
 { control.value }
 </textarea>

--- a/packages/form/core/form-control.ts
+++ b/packages/form/core/form-control.ts
@@ -8,9 +8,10 @@ import type {
 	ControlOption,
 	Submit,
 	ValidationError,
+	TextArea,
 } from '@astro-reactive/common';
 
-export type ControlConfig = ControlBase | Checkbox | Radio | Submit | Button | Dropdown;
+export type ControlConfig = ControlBase | Checkbox | Radio | Submit | Button | Dropdown | TextArea;
 
 export class FormControl {
 	private _name = '';
@@ -24,6 +25,8 @@ export class FormControl {
 	private _validators: string[] = [];
 	private _errors: ValidationError[] = [];
 	private _options: string[] | ControlOption[] = [];
+	private _rows: number | null;
+	private _cols: number | null;
 
 	private validate: (value: string, validators: string[]) => ValidationError[] = (
 		value: string,
@@ -44,6 +47,8 @@ export class FormControl {
 			placeholder = null,
 			validators = [],
 			options = [],
+			rows = null,
+			cols = null,
 		} = config;
 
 		this._name = name;
@@ -54,6 +59,8 @@ export class FormControl {
 		this._placeholder = placeholder;
 		this._validators = validators;
 		this._options = options;
+		this._rows = rows;
+		this._cols = cols;
 
 		// TODO: implement independence
 		// form should try to import validator,
@@ -113,6 +120,14 @@ export class FormControl {
 
 	get options() {
 		return this._options;
+	}
+
+	get rows() {
+		return this._rows;
+	}
+
+	get cols() {
+		return this._cols;
 	}
 
 	setValue(value: string) {

--- a/packages/form/core/form-control.ts
+++ b/packages/form/core/form-control.ts
@@ -1,8 +1,8 @@
 import type {
 	Button,
 	Checkbox,
-	ControlBase,
 	ControlType,
+	TextInput,
 	Radio,
 	Dropdown,
 	ControlOption,
@@ -11,7 +11,7 @@ import type {
 	TextArea,
 } from '@astro-reactive/common';
 
-export type ControlConfig = ControlBase | Checkbox | Radio | Submit | Button | Dropdown | TextArea;
+export type ControlConfig = TextInput | Checkbox | Radio | Submit | Button | Dropdown | TextArea;
 
 export class FormControl {
 	private _name = '';
@@ -25,8 +25,8 @@ export class FormControl {
 	private _validators: string[] = [];
 	private _errors: ValidationError[] = [];
 	private _options: string[] | ControlOption[] = [];
-	private _rows: number | null;
-	private _cols: number | null;
+	private _rows: number | null = null;
+	private _cols: number | null = null;
 
 	private validate: (value: string, validators: string[]) => ValidationError[] = (
 		value: string,
@@ -47,8 +47,6 @@ export class FormControl {
 			placeholder = null,
 			validators = [],
 			options = [],
-			rows = null,
-			cols = null,
 		} = config;
 
 		this._name = name;
@@ -59,8 +57,12 @@ export class FormControl {
 		this._placeholder = placeholder;
 		this._validators = validators;
 		this._options = options;
-		this._rows = rows;
-		this._cols = cols;
+
+		if (config.type === 'textarea') {
+			const { rows = null, cols = null } = config;
+			this._rows = rows;
+			this._cols = cols;
+		}
 
 		// TODO: implement independence
 		// form should try to import validator,

--- a/packages/form/test/TextArea.astro.test.js
+++ b/packages/form/test/TextArea.astro.test.js
@@ -1,0 +1,110 @@
+import { expect } from 'chai';
+import { describe, beforeEach, it } from 'mocha';
+import { getComponentOutput } from 'astro-component-tester';
+import { cleanString } from './utils/index.js';
+
+describe('TextArea.astro test', () => {
+	let component;
+
+	beforeEach(() => {
+		component = undefined;
+	});
+
+	it('Should render a textarea', async () => {
+		// arrange
+		const expectedHTML = '<textarea';
+		const props = {
+			control: {
+				name: 'FAKE NAME',
+				type: 'textarea',
+			},
+		};
+
+		// act
+		component = await getComponentOutput('./components/controls/TextArea.astro', props);
+		const actualResult = cleanString(component.html);
+
+		// assert
+		expect(actualResult).to.contain(expectedHTML);
+	});
+
+	it('Should render a textarea with label', async () => {
+		// arrange
+		const expectedLabel = 'TestLabel';
+		const props = {
+			control: {
+				label: 'TestLabel',
+				name: 'FAKE NAME',
+				type: 'textarea',
+			},
+		};
+
+		// act
+		component = await getComponentOutput('./components/controls/TextArea.astro', props);
+		const actualResult = cleanString(component.html);
+
+		// assert
+		expect(actualResult).to.contain(expectedLabel);
+	});
+
+	it('Should render a textarea with placeholder', async () => {
+		// arrange
+		const expectedAttribute = 'placeholder="test"';
+		const props = {
+			control: {
+				label: 'FAKE LABEL',
+				name: 'FAKE NAME',
+				type: 'textarea',
+				placeholder: 'test',
+			},
+		};
+
+		// act
+		component = await getComponentOutput('./components/controls/TextArea.astro', props);
+		const actualResult = cleanString(component.html);
+
+		// assert
+		expect(actualResult).to.contain(expectedAttribute);
+	});
+
+	it('Should render a textarea with initial value', async () => {
+		// arrange
+		const expectedText = 'hello,world!';
+		const props = {
+			control: {
+				label: 'FAKE LABEL',
+				name: 'FAKE NAME',
+				type: 'textarea',
+				placeholder: 'test',
+				value: 'hello,world!',
+			},
+		};
+
+		// act
+		component = await getComponentOutput('./components/controls/TextArea.astro', props);
+		const actualResult = cleanString(component.html);
+
+		// assert
+		expect(actualResult).to.contain(expectedText);
+	});
+
+	it('Should render a required textarea with data required attribute when showValidationHints is true', async () => {
+		// arrange
+		const expectedAttribute = 'data-validator-required="true"';
+		const props = {
+			control: {
+				label: 'FAKE LABEL',
+				name: 'FAKE NAME',
+				type: 'textarea',
+				validators: ['validator-required'],
+			},
+		};
+
+		// act
+		component = await getComponentOutput('./components/controls/TextArea.astro', props);
+		const actualResult = cleanString(component.html);
+
+		// assert
+		expect(actualResult).to.contain(expectedAttribute);
+	});
+});


### PR DESCRIPTION
## feat(form): implement `TextArea` control

Fixes #161 

Description of changes: 
- Implement `TextArea` control which include `TextArea.astro` and `TextArea` common type.
- The default values of TextArea for `rows` is 3 and `cols` is 21.
  (This is the closest width with the default text input form that I try to play around with).
- Include some tests for `TextArea` control.

Tag a reviewer: @ayoayco 

Tasks:
- [x] I have ran the build command to make sure apps are working: `npm run build`
- [x] I have ran the tests to make sure nothing is broken: `npm run test`
- [x] I have ran the linter to make sure code is clean: `npm run lint`
- [x] I have reviewed my own code to remove changes that are not needed

<!-- THANK YOU FOR THE CONTRIBUTION! 🚀 -->