### PR TITLE
feat(form): implement unique IDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "packages/common"
       ],
       "dependencies": {
-        "prettier-plugin-astro": "^0.7.0"
+        "prettier-plugin-astro": "^0.7.0",
+        "short-unique-id": "^4.4.4"
       }
     },
     "apps/demo": {
@@ -7578,6 +7579,15 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
     },
+    "node_modules/short-unique-id": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-4.4.4.tgz",
+      "integrity": "sha512-oLF1NCmtbiTWl2SqdXZQbo5KM1b7axdp0RgQLq8qCBBLoq+o3A5wmLrNM6bZIh54/a8BJ3l69kTXuxwZ+XCYuw==",
+      "bin": {
+        "short-unique-id": "bin/short-unique-id",
+        "suid": "bin/short-unique-id"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -14420,6 +14430,11 @@
           "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
         }
       }
+    },
+    "short-unique-id": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-4.4.4.tgz",
+      "integrity": "sha512-oLF1NCmtbiTWl2SqdXZQbo5KM1b7axdp0RgQLq8qCBBLoq+o3A5wmLrNM6bZIh54/a8BJ3l69kTXuxwZ+XCYuw=="
     },
     "signal-exit": {
       "version": "3.0.7",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "packages/common"
   ],
   "dependencies": {
-    "prettier-plugin-astro": "^0.7.0"
+    "prettier-plugin-astro": "^0.7.0",
+    "short-unique-id": "^4.4.4"
   }
 }

--- a/packages/form/components/FieldSet.astro
+++ b/packages/form/components/FieldSet.astro
@@ -11,7 +11,7 @@ export interface Props {
 const { group, showValidationHints, readOnly = false } = Astro.props;
 ---
 
-<fieldset id={group.name} name={group.name}>
+<fieldset id={group.id} name={group.name}>
 	{group.name && <legend>{group.name}</legend>}
 	{
 		group?.controls?.map((control) => (

--- a/packages/form/components/Form.astro
+++ b/packages/form/components/Form.astro
@@ -22,7 +22,7 @@ const {
 
 const formTheme = theme ?? 'light';
 const formName = Array.isArray(formGroups) ? null : formGroups?.name || null;
-const formId = Array.isArray(formGroups) ? null : formGroups?.id || null;
+const formId = Array.isArray(formGroups) ? uuid() : formGroups?.id || null;
 ---
 
 <form

--- a/packages/form/components/Form.astro
+++ b/packages/form/components/Form.astro
@@ -3,6 +3,7 @@ import type { Submit } from '@astro-reactive/common';
 import { FormGroup, FormControl } from '../core';
 import FieldSet from './FieldSet.astro';
 import Field from './Field.astro';
+import ShortUniqueId from 'short-unique-id';
 
 export interface Props {
 	formGroups: FormGroup | FormGroup[];
@@ -20,9 +21,10 @@ const {
 	readOnly = false,
 } = Astro.props;
 
+const uid = new ShortUniqueId({ length: 9 });
 const formTheme = theme ?? 'light';
 const formName = Array.isArray(formGroups) ? null : formGroups?.name || null;
-const formId = Array.isArray(formGroups) ? uuid() : formGroups?.id || null;
+const formId = Array.isArray(formGroups) ? uid() : formGroups?.id || null;
 ---
 
 <form

--- a/packages/form/components/Form.astro
+++ b/packages/form/components/Form.astro
@@ -22,12 +22,13 @@ const {
 
 const formTheme = theme ?? 'light';
 const formName = Array.isArray(formGroups) ? null : formGroups?.name || null;
+const formId = Array.isArray(formGroups) ? null : formGroups?.id || null;
 ---
 
 <form
 	class={formTheme}
 	name={formName}
-	id={formName}
+	id={formId}
 	data-validator-hints={showValidationHints.toString()}
 >
 	{

--- a/packages/form/components/Label.astro
+++ b/packages/form/components/Label.astro
@@ -16,7 +16,7 @@ const isRequired: boolean = showValidationHints && validators.includes('validato
 
 {
 	control.label && control.type !== "checkbox" && (
-		<label for={control.name} data-validation-required={isRequired ? "true" : null}>
+		<label for={control.id} data-validation-required={isRequired ? "true" : null}>
 			{control.label}
 		</label>
 	)
@@ -26,7 +26,7 @@ const isRequired: boolean = showValidationHints && validators.includes('validato
 
 {
 	control.label && control.type === "checkbox" && (
-		<label for={control.name} data-validation-required={isRequired ? "true" : null}>
+		<label for={control.id} data-validation-required={isRequired ? "true" : null}>
 			{control.label}
 		</label>
 	)

--- a/packages/form/components/controls/Dropdown.astro
+++ b/packages/form/components/controls/Dropdown.astro
@@ -24,7 +24,7 @@ const options = control.options.map((option: string | ControlOption) => {
 
 <select
 	name={control.name}
-	id={control.name}
+	id={control.id}
 	disabled={readOnly || null}
 >
 {

--- a/packages/form/components/controls/Input.astro
+++ b/packages/form/components/controls/Input.astro
@@ -30,7 +30,7 @@ const validatorAttributes: Record<string, string> = validators?.reduce((prev, va
 
 <input
 	name={control.name}
-	id={control.name}
+	id={control.id}
 	type={control.type as InputType}
 	value={control.value?.toString()}
 	checked={control.value === 'checked'}

--- a/packages/form/components/controls/RadioGroup.astro
+++ b/packages/form/components/controls/RadioGroup.astro
@@ -27,6 +27,7 @@ const options = control.options.map((option: string | ControlOption) => {
 		<div class="radio-option">
 			<input
 				type="radio"
+				id={control.id}
 				name={control.name}
 				value={option.value}
 				checked={option.value === control.value}

--- a/packages/form/components/controls/TextArea.astro
+++ b/packages/form/components/controls/TextArea.astro
@@ -27,7 +27,7 @@ const validatorAttributes: Record<string, string> = validators?.reduce((prev, va
 
 <textarea
 	name={control.name}
-	id={control.name}
+	id={control.id}
 	placeholder={control?.placeholder}
 	rows={control?.rows ?? 3}
 	cols={control?.cols ?? 21}

--- a/packages/form/core/form-control.ts
+++ b/packages/form/core/form-control.ts
@@ -10,10 +10,12 @@ import type {
 	TextArea,
 	ControlBase,
 } from '@astro-reactive/common';
+import ShortUniqueId from 'short-unique-id';
 
 export type ControlConfig = ControlBase | Checkbox | Radio | Submit | Button | Dropdown | TextArea;
 
 export class FormControl {
+	private _id = '';
 	private _name = '';
 	private _type: ControlType = 'text';
 	private _value?: string | number | null | string[] | ControlOption[];
@@ -46,6 +48,8 @@ export class FormControl {
 			validators = [],
 		} = config;
 
+		const uid = new ShortUniqueId({ length: 9 });
+		this._id = 'arl-' + uid();
 		this._name = name;
 		this._type = type;
 		this._value = value;
@@ -78,6 +82,10 @@ export class FormControl {
 				this._errors = [];
 			}
 		});
+	}
+
+	get id() {
+		return this._id;
 	}
 
 	get name() {

--- a/packages/form/core/form-group.ts
+++ b/packages/form/core/form-group.ts
@@ -1,11 +1,15 @@
 import { ControlConfig, FormControl } from './form-control';
+import ShortUniqueId from 'short-unique-id';
 
 export class FormGroup {
 	controls: FormControl[];
 	name?: string;
+	id?: string;
 
 	constructor(controls: ControlConfig[], name = '') {
+		const uid = new ShortUniqueId({ length: 9 });
 		this.name = name;
+		this.id = 'arl-' + uid();
 		this.controls = controls
 			.filter((control) => control.type !== 'submit')
 			.map((control) => new FormControl(control));


### PR DESCRIPTION
## feat(form): implement unique IDs
<!--
☝️ Put your PR title up here!

"scope" could be one of our apps or packages:
- form, validator, demo, landing-page, docs...

✨ Example PR titles:
    - feat(form): implement new FormControl isValid state
    - fix(validator): correct the variable name typo causing errors
    - style(landing-page): update the logo in the landing page app
    - docs: update content project CONTRIBUTING.md
-->

Fixes #140 <!-- 👈🏻 Put the issue number here! -->

Description of changes: <!-- 👇🏻 List the changes done! -->
- Added a `npm` library: [Short Unique ID (UUID) Generating Library](https://github.com/simplyhexagonal/short-unique-id)
    - Used for generating unique IDs for form components
- Added ID properties to both `form-control` and `form-group`
- Replaced all instances in the components where `id` is assigned the `name` value to use the `id` value instead.
- Added an `id` value to `RadioGroup` as there was none before.

Note: When I ran `npm run test`, some tests failed but those same tests also failed before I made any changes.

Tag a reviewer: @ayoayco 

Tasks:
- [x] I have ran the build command to make sure apps are working: `npm run build`
- [ ] I have ran the tests to make sure nothing is broken: `npm run test`
- [x] I have ran the linter to make sure code is clean: `npm run lint`
- [x] I have reviewed my own code to remove changes that are not needed

<!-- THANK YOU FOR THE CONTRIBUTION! 🚀 -->