### PR TITLE
feat(form): add `setValue` method to FormGroup class

### DIFF
--- a/apps/demo/src/pages/job-application.astro
+++ b/apps/demo/src/pages/job-application.astro
@@ -7,7 +7,6 @@ import Form, {
 } from "@astro-reactive/form";
 import { Validators } from "@astro-reactive/validator";
 import type { Submit } from "@astro-reactive/common";
-import { info } from "astro/dist/core/logger/core";
 
 const infoForm = new FormGroup([
   {

--- a/apps/demo/src/pages/job-application.astro
+++ b/apps/demo/src/pages/job-application.astro
@@ -7,6 +7,7 @@ import Form, {
 } from "@astro-reactive/form";
 import { Validators } from "@astro-reactive/validator";
 import type { Submit } from "@astro-reactive/common";
+import { info } from "astro/dist/core/logger/core";
 
 const infoForm = new FormGroup([
   {
@@ -100,6 +101,16 @@ const submit: Submit = {
   name: "submit",
   type: "submit",
 };
+
+const values = {
+  firstName: "James",
+  lastName: "Bond",
+  email: "james.bond@gmail.com",
+  country: "U.S.A",
+  eligible: "yes"
+}
+
+infoForm.setValue(values);
 
 infoForm.name = "Application Form";
 skillsForm.name = "Skills";

--- a/packages/form/core/form-group.ts
+++ b/packages/form/core/form-group.ts
@@ -18,4 +18,14 @@ export class FormGroup {
 	get(name: string): FormControl | undefined {
 		return this.controls.find((control) => control.name === name);
 	}
+
+	setValue(values: object) {
+		this.controls.map((control) => {
+			for (const value in values) {
+				if (value == control.name) {
+					control.setValue(values[value]);
+				}
+			}
+		});
+	}
 }

--- a/packages/form/core/form-group.ts
+++ b/packages/form/core/form-group.ts
@@ -20,12 +20,6 @@ export class FormGroup {
 	}
 
 	setValue(values: object) {
-		this.controls.map((control) => {
-			for (const value in values) {
-				if (value == control.name) {
-					control.setValue(values[value]);
-				}
-			}
-		});
+		Object.keys(values).forEach((name) => this.get(name)?.setValue(values[name as keyof object]));
 	}
 }


### PR DESCRIPTION
## feat(form): add `setValue` method to FormGroup class
<!--
☝️ Put your PR title up here!

"scope" could be one of our apps or packages:
- form, validator, demo, landing-page, docs...

✨ Example PR titles:
    - feat(form): implement new FormControl isValid state
    - fix(validator): correct the variable name typo causing errors
    - style(landing-page): update the logo in the landing page app
    - docs: update content project CONTRIBUTING.md
-->

Fixes #175  <!-- 👈🏻 Put the issue number here! -->

Description of changes: <!-- 👇🏻 List the changes done! -->
- Created a new `setValue` method in the FormGroup class which will set the values for any FormControls in the FormGroup.
- Updated the job application demo page to use the new `setValue` method. For example the following code:
![image](https://user-images.githubusercontent.com/54966170/201451614-8f68250d-576e-4be4-9297-51256c211700.png)
will produce the following page:
![image](https://user-images.githubusercontent.com/54966170/201451649-dfb4b104-7f6b-45a5-9fb6-0e2b0d335b98.png)

Tag a reviewer: @ayoayco 

Tasks:
- [x] I have ran the build command to make sure apps are working: `npm run build`
- [x] I have ran the tests to make sure nothing is broken: `npm run test`
- [x] I have ran the linter to make sure code is clean: `npm run lint`
- [x] I have reviewed my own code to remove changes that are not needed

<!-- THANK YOU FOR THE CONTRIBUTION! 🚀 -->