### PR TITLE
fix(validator): use a checked attribute for required validation in checkboxes

### DIFF
--- a/packages/validator/Validator.astro
+++ b/packages/validator/Validator.astro
@@ -40,7 +40,8 @@ const { hook = 'all', displayErrorMessages = false } = Astro.props;
 					const limit = element.getAttribute(attribute);
 					return `${attribute}:${limit}`;
 				});
-			const value = element.type === 'checkbox' ? element.checked : element.value;
+			const value =
+				element.type === 'checkbox' ? (element.checked ? 'checked' : '') : element.value;
 			const errors = validate(value, validators);
 
 			// set element hasErrors

--- a/packages/validator/Validator.astro
+++ b/packages/validator/Validator.astro
@@ -40,7 +40,7 @@ const { hook = 'all', displayErrorMessages = false } = Astro.props;
 					const limit = element.getAttribute(attribute);
 					return `${attribute}:${limit}`;
 				});
-			const value = element.value;
+			const value = element.type === 'checkbox' ? element.checked : element.value;
 			const errors = validate(value, validators);
 
 			// set element hasErrors


### PR DESCRIPTION
## fix(validator): use a `checked` attribute for required validation in checkboxes

Fixes #141 

Description of changes:
- Use a `checked` attribute instead of a `value` attribute for checkboxes input form.

Tag a reviewer: @ayoayco 
Tasks:
- [x] I have ran the build command to make sure apps are working: `npm run build`
- [x] I have ran the tests to make sure nothing is broken: `npm run test`
- [x] I have ran the linter to make sure code is clean: `npm run lint`
- [x] I have reviewed my own code to remove changes that are not needed

<!-- THANK YOU FOR THE CONTRIBUTION! 🚀 -->