### PR TITLE
refactor(form): validation attributes set null instead of false

### DIFF
--- a/packages/form/components/Field.astro
+++ b/packages/form/components/Field.astro
@@ -20,16 +20,16 @@ export interface Props {
 
 const { control, showValidationHints, showErrors = false, readOnly = false } = Astro.props;
 
-const hasError: boolean = control.errors?.length ? control.errors[0]?.category === 'error' : false;
-const hasWarn: boolean = control.errors?.length ? control.errors[0]?.category === 'warn' : false;
-const hasInfo: boolean = control.errors?.length ? control.errors[0]?.category === 'info' : false;
+const hasError: boolean = control.errors?.some((error) => error.category === 'error');
+const hasWarn: boolean = control.errors?.some((error) => error.category === 'warn');
+const hasInfo: boolean = control.errors?.some((error) => error.category === 'info');
 ---
 
 <div
 	class="field"
-	data-validator-error={hasError.toString()}
-	data-validator-warn={hasWarn.toString()}
-	data-validator-info={hasInfo.toString()}
+	data-validator-error={hasError ? hasError.toString() : null}
+	data-validator-warn={hasWarn ? hasWarn.toString() : null}
+	data-validator-info={hasInfo ? hasInfo.toString() : null}
 >
 	<Label control={control} showValidationHints={showValidationHints}>
 		{

--- a/packages/form/components/Form.astro
+++ b/packages/form/components/Form.astro
@@ -72,7 +72,7 @@ const formId = Array.isArray(formGroups) ? uid() : formGroups?.id || null;
 	}
 	[data-validator-hints='true'][data-validator-info='true'],
 	[data-validator-hints='true'] [data-validator-info='true'] {
-		color: blue;
-		border-color: blue;
+		color: green;
+		border-color: green;
 	}
 </style>

--- a/packages/form/components/controls/Input.astro
+++ b/packages/form/components/controls/Input.astro
@@ -14,9 +14,9 @@ const { control, readOnly } = Astro.props;
 
 const { validators = [] } = control;
 
-const hasError: boolean = control.errors?.length ? control.errors[0]?.category === 'error' : false;
-const hasWarn: boolean = control.errors?.length ? control.errors[0]?.category === 'warn' : false;
-const hasInfo: boolean = control.errors?.length ? control.errors[0]?.category === 'info' : false;
+const hasError: boolean = control.errors?.some((error) => error.category === 'error');
+const hasWarn: boolean = control.errors?.some((error) => error.category === 'warn');
+const hasInfo: boolean = control.errors?.some((error) => error.category === 'info');
 
 // @ts-ignore
 const validatorAttributes: Record<string, string> = validators.reduce((prev, val) => {
@@ -43,9 +43,9 @@ const validatorAttributes: Record<string, string> = validators.reduce((prev, val
 	checked={control.value === 'checked'}
 	placeholder={control.placeholder}
 	data-label={control.label}
-	data-validator-error={hasError.toString()}
-	data-validator-warn={hasWarn.toString()}
-	data-validator-info={hasInfo.toString()}
+	data-validator-error={hasError ? hasError.toString() : null}
+	data-validator-warn={hasWarn ? hasWarn.toString() : null}
+	data-validator-info={hasInfo ? hasInfo.toString() : null}
 	readonly={readOnly || null}
 	disabled={(readOnly || null) && control.type === 'checkbox'}
 	{...validatorAttributes}


### PR DESCRIPTION
## refactor(form): validation attributes set null instead of false

Description of changes: <!-- 👇🏻 List the changes done! -->
- validation attributes are now set to null instead of false, so the attribute will not be rendered resulting in cleaner HTML
- validation-info is now green instead of blue

Tag a reviewer: @Lalit3716 / @Icyscools 

Tasks:
- [x] I have ran the build command to make sure apps are working: `npm run build`
- [x] I have ran the tests to make sure nothing is broken: `npm run test`
- [x] I have ran the linter to make sure code is clean: `npm run lint`
- [x] I have reviewed my own code to remove changes that are not needed

<!-- THANK YOU FOR THE CONTRIBUTION! 🚀 -->