### PR TITLE
test(form): Added test Field.astro to test for category validation prop

### DIFF
--- a/packages/form/test/Field.astro.test.ts
+++ b/packages/form/test/Field.astro.test.ts
@@ -98,4 +98,31 @@ describe('Field.astro test', () => {
 		expect(actualResult).to.contain(expectedLabel);
 		expect(actualResult).to.contain(expectedAttribute);
 	});
+
+	it('Should render correct validation attribute based on category prop', async () => {
+		// arrange
+		const expected = 'data-validator-warn="true"';
+		const props = {
+			control: {
+				label: 'FAKE LABEL',
+				name: 'username',
+				validators: ['validator-required'],
+				errors: [
+					{
+						error: 'required',
+						category: 'warn',
+					},
+				],
+				value: '',
+			},
+			showValidationHints: true,
+		};
+
+		// act
+		component = await getComponentOutput('./components/Field.astro', props);
+		const actualResult = cleanString(component.html);
+
+		// assert
+		expect(actualResult).to.contain(expected);
+	});
 });

--- a/packages/form/test/Field.astro.test.ts
+++ b/packages/form/test/Field.astro.test.ts
@@ -101,7 +101,7 @@ describe('Field.astro test', () => {
 
 	it('Should render correct validation attribute based on category prop', async () => {
 		// arrange
-		const expected = 'data-validator-warn="true"';
+		const categories = ['error', 'warn', 'info'];
 		const props = {
 			control: {
 				label: 'FAKE LABEL',
@@ -110,7 +110,7 @@ describe('Field.astro test', () => {
 				errors: [
 					{
 						error: 'required',
-						category: 'warn',
+						category: 'error',
 					},
 				],
 				value: '',
@@ -119,10 +119,18 @@ describe('Field.astro test', () => {
 		};
 
 		// act
-		component = await getComponentOutput('./components/Field.astro', props);
-		const actualResult = cleanString(component.html);
+		const results = await Promise.all(
+			categories.map(async (category) => {
+				props.control.errors = [{ error: 'required', category }];
+				component = await getComponentOutput('./components/Field.astro', props);
+				const actualResult = cleanString(component.html);
+				return actualResult;
+			})
+		);
 
 		// assert
-		expect(actualResult).to.contain(expected);
+		categories.forEach((category, index) => {
+			expect(results[index]).to.contain(`data-validator-${category}="true"`);
+		});
 	});
 });


### PR DESCRIPTION
## test(form): Added test for field.astro to check category validation prop.
<!--
☝️ Put your PR title up here!

"scope" could be one of our apps or packages:
- form, validator, demo, landing-page, docs...

✨ Example PR titles:
    - feat(form): implement new FormControl isValid state
    - fix(validator): correct the variable name typo causing errors
    - style(landing-page): update the logo in the landing page app
    - docs: update content project CONTRIBUTING.md
-->

Description of changes: <!-- 👇🏻 List the changes done! -->
- Added a test for testing category validator prop.

Tag a reviewer: @ayoayco, @Icyscools, @fazzaamiarso 

Tasks:
- [x] I have ran the build command to make sure apps are working: `npm run build`
- [x] I have ran the tests to make sure nothing is broken: `npm run test`
- [x] I have ran the linter to make sure code is clean: `npm run lint`
- [x] I have reviewed my own code to remove changes that are not needed

<!-- THANK YOU FOR THE CONTRIBUTION! 🚀 -->