### PR TITLE
feat(form): implement FormControl and ControlConfig prop `triggerValidationOn`

### DIFF
--- a/packages/common/types/control.types.ts
+++ b/packages/common/types/control.types.ts
@@ -1,4 +1,4 @@
-import type { ValidatorRules } from "./validator.types";
+import type { ValidationHooks, ValidatorRules } from "./validator.types";
 
 /**
  * `ControlType` determines the type of form control
@@ -37,6 +37,7 @@ export interface ControlBase {
   label?: string;
   placeholder?: string;
   validators?: ValidatorRules;
+  triggerValidationOn?: ValidationHooks; 
 }
 
 export interface Checkbox extends ControlBase {

--- a/packages/common/types/validator.types.ts
+++ b/packages/common/types/validator.types.ts
@@ -1,6 +1,6 @@
 export type HookType = "onSubmit" | "onControlBlur" | "all";
 
-export type ValidationHooks = "" | "blur" | "keypress"; // More to be added
+export type ValidationHooks = "" | "blur" | "keypress" | "click"; // More to be added
 
 export type CategoryType = "error" | "warn" | "info";
 

--- a/packages/common/types/validator.types.ts
+++ b/packages/common/types/validator.types.ts
@@ -1,5 +1,7 @@
 export type HookType = "onSubmit" | "onControlBlur" | "all";
 
+export type ValidationHooks = "" | "blur" | "keypress"; // More to be added
+
 export type CategoryType = "error" | "warn" | "info";
 
 export type ValidatorRules =

--- a/packages/form/components/controls/Dropdown.astro
+++ b/packages/form/components/controls/Dropdown.astro
@@ -6,7 +6,7 @@ import type { Dropdown, ControlOption } from '@astro-reactive/common';
 
 export interface Props {
 	control: Dropdown;
-  readOnly?: boolean;
+	readOnly?: boolean;
 }
 
 const { control, readOnly } = Astro.props;
@@ -26,22 +26,20 @@ const options = control.options.map((option: string | ControlOption) => {
 	name={control.name}
 	id={control.id}
 	disabled={readOnly || null}
+	data-validation-on={control.triggerValidationOn ? control.triggerValidationOn : null}
 >
-{
-	control?.placeholder && (
-		<option value="" disabled selected={!control?.value}>
-			{control.placeholder}
-        </option>
-	)
-}
-{	
-	options.map((option: ControlOption) => (
-        <option
-			value={option.value} 
-			selected={option.value === control.value}
-		>
-			{option.label}
-        </option>
-	))
-}
+	{
+		control?.placeholder && (
+			<option value="" disabled selected={!control?.value}>
+				{control.placeholder}
+			</option>
+		)
+	}
+	{
+		options.map((option: ControlOption) => (
+			<option value={option.value} selected={option.value === control.value}>
+				{option.label}
+			</option>
+		))
+	}
 </select>

--- a/packages/form/components/controls/Input.astro
+++ b/packages/form/components/controls/Input.astro
@@ -46,6 +46,7 @@ const validatorAttributes: Record<string, string> = validators.reduce((prev, val
 	data-validator-error={hasError ? hasError.toString() : null}
 	data-validator-warn={hasWarn ? hasWarn.toString() : null}
 	data-validator-info={hasInfo ? hasInfo.toString() : null}
+	data-validation-on={control.triggerValidationOn ? control.triggerValidationOn  : null}
 	readonly={readOnly || null}
 	disabled={(readOnly || null) && control.type === 'checkbox'}
 	{...validatorAttributes}

--- a/packages/form/components/controls/RadioGroup.astro
+++ b/packages/form/components/controls/RadioGroup.astro
@@ -33,6 +33,7 @@ const options = control.options.map((option: string | ControlOption) => {
 				checked={option.value === control.value}
 				readonly={readOnly || null}
 				disabled={readOnly || null}
+				data-validation-on={control.triggerValidationOn ? control.triggerValidationOn : null}
 			/>
 			<label for={control.id + '-' + index}>{option.label}</label>
 		</div>

--- a/packages/form/components/controls/TextArea.astro
+++ b/packages/form/components/controls/TextArea.astro
@@ -38,6 +38,7 @@ const validatorAttributes: Record<string, string> = validators.reduce((prev, val
 	cols={control?.cols ?? 21}
 	data-label={control?.label}
 	readonly={readOnly || null}
+	data-validation-on={control.triggerValidationOn ? control.triggerValidationOn : null}
 	{...validatorAttributes}
 >
 	{control.value}

--- a/packages/form/core/form-control.ts
+++ b/packages/form/core/form-control.ts
@@ -49,7 +49,7 @@ export class FormControl {
 			label = '',
 			placeholder = null,
 			validators = [],
-			triggerValidationOn = '',
+			triggerValidationOn = 'blur',
 		} = config;
 
 		const uid = new ShortUniqueId({ length: 9 });

--- a/packages/form/core/form-control.ts
+++ b/packages/form/core/form-control.ts
@@ -10,6 +10,7 @@ import type {
 	TextArea,
 	ControlBase,
 	ValidatorRules,
+	ValidationHooks,
 } from '@astro-reactive/common';
 import ShortUniqueId from 'short-unique-id';
 
@@ -25,6 +26,7 @@ export class FormControl {
 	private _isPristine = true;
 	private _placeholder: string | null = null;
 	private _validators: ValidatorRules = [];
+	private _triggerValidationOn: ValidationHooks;
 	private _errors: ValidationError[] = [];
 	private _options: string[] | ControlOption[] = [];
 	private _rows: number | null = null;
@@ -47,6 +49,7 @@ export class FormControl {
 			label = '',
 			placeholder = null,
 			validators = [],
+			triggerValidationOn = '',
 		} = config;
 
 		const uid = new ShortUniqueId({ length: 9 });
@@ -57,6 +60,7 @@ export class FormControl {
 		this._label = label;
 		this._placeholder = placeholder;
 		this._validators = validators;
+		this._triggerValidationOn = triggerValidationOn;
 
 		if (type === 'radio' || type === 'dropdown') {
 			const { options = [] } = config as Radio | Dropdown;
@@ -109,6 +113,10 @@ export class FormControl {
 
 	get validators() {
 		return this._validators;
+	}
+
+	get triggerValidationOn() {
+		return this._triggerValidationOn;
 	}
 
 	get errors() {

--- a/packages/validator/Validator.astro
+++ b/packages/validator/Validator.astro
@@ -28,7 +28,7 @@ const { hook = 'all', displayErrorMessages = false } = Astro.props;
 	import { clearErrors, validate } from './core';
 
 	// const hook: HookType = (document.getElementById('hook') as HTMLInputElement).value as HookType;
-	const inputs = [...document.querySelectorAll('form input')] as HTMLInputElement[];
+	const inputs = [...document.querySelectorAll('*')] as HTMLInputElement[];
 
 	inputs?.forEach((input) => {
 		if (input.dataset.validationOn) {

--- a/packages/validator/Validator.astro
+++ b/packages/validator/Validator.astro
@@ -31,37 +31,39 @@ const { hook = 'all', displayErrorMessages = false } = Astro.props;
 	const inputs = [...document.querySelectorAll('form input')] as HTMLInputElement[];
 
 	inputs?.forEach((input) => {
-		input.addEventListener('blur', (e: Event) => {
-			// NOTE: event target attribute names are converted to lowercase
-			const element = e.target as HTMLInputElement;
-			const attributeNames = element?.getAttributeNames() || [];
-			const validators = attributeNames
-				.filter((attribute) => attribute.includes('data-validator-'))
-				.map((attribute) => {
-					const limit = element.getAttribute(attribute);
-					return {
-						validator: `${attribute}:${limit}`,
-						category: element.getAttribute(`${attribute}-category`),
-					};
-				})
-				.filter((val) => val.category !== null); // Filter out validators without a category
+		if (input.dataset.validationOn) {
+			input.addEventListener(input.dataset.validationOn, (e: Event) => {
+				// NOTE: event target attribute names are converted to lowercase
+				const element = e.target as HTMLInputElement;
+				const attributeNames = element?.getAttributeNames() || [];
+				const validators = attributeNames
+					.filter((attribute) => attribute.includes('data-validator-'))
+					.map((attribute) => {
+						const limit = element.getAttribute(attribute);
+						return {
+							validator: `${attribute}:${limit}`,
+							category: element.getAttribute(`${attribute}-category`),
+						};
+					})
+					.filter((val) => val.category !== null); // Filter out validators without a category
 
-			const value =
-				element.type === 'checkbox' ? (element.checked ? 'checked' : '') : element.value;
-			const errors = validate(value, validators as ValidatorRules);
+				const value =
+					element.type === 'checkbox' ? (element.checked ? 'checked' : '') : element.value;
+				const errors = validate(value, validators as ValidatorRules);
 
-			// set element hasErrors
-			if (errors.length) {
-				element.parentElement?.setAttribute(`data-validator-${errors[0]?.category}`, 'true');
-				element.setAttribute(`data-validator-${errors[0]?.category}`, 'true');
-				element.classList.add(`has-errors`);
-				// TODO: display error messages
-			} else {
-				element.parentElement?.removeAttribute(`data-validator-${errors[0]?.category}`);
-				element.removeAttribute(`data-validator-${errors[0]?.category}`);
-				element.classList.remove(`has-${errors[0]?.category}`);
-			}
-		});
+				// set element hasErrors
+				if (errors.length) {
+					element.parentElement?.setAttribute(`data-validator-${errors[0]?.category}`, 'true');
+					element.setAttribute(`data-validator-${errors[0]?.category}`, 'true');
+					element.classList.add(`has-errors`);
+					// TODO: display error messages
+				} else {
+					element.parentElement?.removeAttribute(`data-validator-${errors[0]?.category}`);
+					element.removeAttribute(`data-validator-${errors[0]?.category}`);
+					element.classList.remove(`has-${errors[0]?.category}`);
+				}
+			});
+		}
 
 		input.addEventListener('input', clearErrors);
 	});

--- a/packages/validator/Validator.astro
+++ b/packages/validator/Validator.astro
@@ -31,7 +31,7 @@ const { hook = 'all', displayErrorMessages = false } = Astro.props;
 	const inputs = [...document.querySelectorAll('body *[data-validation-on]')] as HTMLInputElement[];
 
 	inputs?.forEach((input) => {
-		input.addEventListener(input.dataset.validationOn, (e: Event) => {
+		input.addEventListener(input.dataset.validationOn ?? 'blur', (e: Event) => {
 			// NOTE: event target attribute names are converted to lowercase
 			const element = e.target as HTMLInputElement;
 			const attributeNames = element?.getAttributeNames() || [];

--- a/packages/validator/Validator.astro
+++ b/packages/validator/Validator.astro
@@ -31,7 +31,7 @@ const { hook = 'all', displayErrorMessages = false } = Astro.props;
 	const inputs = [...document.querySelectorAll('body *[data-validation-on]')] as HTMLInputElement[];
 
 	inputs?.forEach((input) => {
-		input.addEventListener(input.dataset.validationOn ?? 'blur', (e: Event) => {
+		input.addEventListener(input.dataset?.validationOn ?? 'blur', (e: Event) => {
 			// NOTE: event target attribute names are converted to lowercase
 			const element = e.target as HTMLInputElement;
 			const attributeNames = element?.getAttributeNames() || [];

--- a/packages/validator/Validator.astro
+++ b/packages/validator/Validator.astro
@@ -28,42 +28,40 @@ const { hook = 'all', displayErrorMessages = false } = Astro.props;
 	import { clearErrors, validate } from './core';
 
 	// const hook: HookType = (document.getElementById('hook') as HTMLInputElement).value as HookType;
-	const inputs = [...document.querySelectorAll('*')] as HTMLInputElement[];
+	const inputs = [...document.querySelectorAll('body *[data-validation-on]')] as HTMLInputElement[];
 
 	inputs?.forEach((input) => {
-		if (input.dataset.validationOn) {
-			input.addEventListener(input.dataset.validationOn, (e: Event) => {
-				// NOTE: event target attribute names are converted to lowercase
-				const element = e.target as HTMLInputElement;
-				const attributeNames = element?.getAttributeNames() || [];
-				const validators = attributeNames
-					.filter((attribute) => attribute.includes('data-validator-'))
-					.map((attribute) => {
-						const limit = element.getAttribute(attribute);
-						return {
-							validator: `${attribute}:${limit}`,
-							category: element.getAttribute(`${attribute}-category`),
-						};
-					})
-					.filter((val) => val.category !== null); // Filter out validators without a category
+		input.addEventListener(input.dataset.validationOn, (e: Event) => {
+			// NOTE: event target attribute names are converted to lowercase
+			const element = e.target as HTMLInputElement;
+			const attributeNames = element?.getAttributeNames() || [];
+			const validators = attributeNames
+				.filter((attribute) => attribute.includes('data-validator-'))
+				.map((attribute) => {
+					const limit = element.getAttribute(attribute);
+					return {
+						validator: `${attribute}:${limit}`,
+						category: element.getAttribute(`${attribute}-category`),
+					};
+				})
+				.filter((val) => val.category !== null); // Filter out validators without a category
 
-				const value =
-					element.type === 'checkbox' ? (element.checked ? 'checked' : '') : element.value;
-				const errors = validate(value, validators as ValidatorRules);
+			const value =
+				element.type === 'checkbox' ? (element.checked ? 'checked' : '') : element.value;
+			const errors = validate(value, validators as ValidatorRules);
 
-				// set element hasErrors
-				if (errors.length) {
-					element.parentElement?.setAttribute(`data-validator-${errors[0]?.category}`, 'true');
-					element.setAttribute(`data-validator-${errors[0]?.category}`, 'true');
-					element.classList.add(`has-errors`);
-					// TODO: display error messages
-				} else {
-					element.parentElement?.removeAttribute(`data-validator-${errors[0]?.category}`);
-					element.removeAttribute(`data-validator-${errors[0]?.category}`);
-					element.classList.remove(`has-${errors[0]?.category}`);
-				}
-			});
-		}
+			// set element hasErrors
+			if (errors.length) {
+				element.parentElement?.setAttribute(`data-validator-${errors[0]?.category}`, 'true');
+				element.setAttribute(`data-validator-${errors[0]?.category}`, 'true');
+				element.classList.add(`has-errors`);
+				// TODO: display error messages
+			} else {
+				element.parentElement?.removeAttribute(`data-validator-${errors[0]?.category}`);
+				element.removeAttribute(`data-validator-${errors[0]?.category}`);
+				element.classList.remove(`has-${errors[0]?.category}`);
+			}
+		});
 
 		input.addEventListener('input', clearErrors);
 	});


### PR DESCRIPTION
## feat(form): implement FormControl and ControlConfig prop triggerValidationOn
<!--
☝️ Put your PR title up here!

"scope" could be one of our apps or packages:
- form, validator, demo, landing-page, docs...

✨ Example PR titles:
    - feat(form): implement new FormControl isValid state
    - fix(validator): correct the variable name typo causing errors
    - style(landing-page): update the logo in the landing page app
    - docs: update content project CONTRIBUTING.md
-->

Fixes #201 <!-- 👈🏻 Put the issue number here! -->

Description of changes: <!-- 👇🏻 List the changes done! -->
- Created a new type in [validator.types.ts](https://github.com/alexsam29/astro-reactive-library/blob/9ee7442b389207960ab0b14c354bbd8d2cecac63/packages/common/types/validator.types.ts#L3) called `ValidationHooks`.
    - This is used to define different types of event listeners. I only added 3 basic ones (`blur`, `keypress`, and `click`), but more can and should be added.
- Added a new attribute to the interface `ControlBase` in [control.types.ts](https://github.com/alexsam29/astro-reactive-library/blob/9ee7442b389207960ab0b14c354bbd8d2cecac63/packages/common/types/control.types.ts#L40) called ` triggerValidationOn`
    - This will hold the user specified event listener
- Added an additional class variable in [FormControl](https://github.com/alexsam29/astro-reactive-library/blob/9ee7442b389207960ab0b14c354bbd8d2cecac63/packages/form/core/form-control.ts#L29) called ` _triggerValidationOn`.
    - The user specified event listener will be assigned to this variable to use in the `<input>` elements.
- Added a data attribute called `data-validation-on` in [input.astro](https://github.com/alexsam29/astro-reactive-library/blob/9ee7442b389207960ab0b14c354bbd8d2cecac63/packages/form/components/controls/Input.astro#L49) to hold  the user specified event listener type. Will be `null` is no type is specified.
- Adjusted [Validator.astro](https://github.com/alexsam29/astro-reactive-library/blob/9ee7442b389207960ab0b14c354bbd8d2cecac63/packages/validator/Validator.astro#L34) to use the data attribute `valaidationOn` to get the event listener type from `<input>` elements.

Notes:
- Demo pages now need to be adjusted to specify event listener types. Since the default is `null` if nothing is specified, there's no validation anymore.
- As mentioned, need to add more event listener types. Since there's a lot, I'm not sure what we consider "crucial" to add.

Let me know if any adjustments are needed. I can also fix the demo pages and add more event listener types in the same PR, if necessary.

Tag a reviewer: @ayoayco 

Tasks:
- [x] I have ran the build command to make sure apps are working: `npm run build`
- [x] I have ran the tests to make sure nothing is broken: `npm run test`
- [x] I have ran the linter to make sure code is clean: `npm run lint`
- [x] I have reviewed my own code to remove changes that are not needed

<!-- THANK YOU FOR THE CONTRIBUTION! 🚀 -->