### PR TITLE
feat(validator): add validation support for `RadioGroup`

### DIFF
--- a/packages/form/components/controls/RadioGroup.astro
+++ b/packages/form/components/controls/RadioGroup.astro
@@ -21,11 +21,10 @@ const options = control.options.map((option: string | ControlOption) => {
 	return option;
 });
 ---
-
+<br>
 {
 	options.map((option: ControlOption, index: number) => (
-		<div class="radio-option">
-			<input
+		<input
 				type="radio"
 				id={control.id + '-' + index}
 				name={control.name}
@@ -36,6 +35,6 @@ const options = control.options.map((option: string | ControlOption) => {
 				data-validation-on={control.triggerValidationOn ? control.triggerValidationOn : null}
 			/>
 			<label for={control.id + '-' + index}>{option.label}</label>
-		</div>
+			<br>
 	))
 }

--- a/packages/form/test/RadioGroup.astro.test.ts
+++ b/packages/form/test/RadioGroup.astro.test.ts
@@ -12,7 +12,7 @@ describe('RadioGroup.astro test', () => {
 	it('Should render all radio options', async () => {
 		// arrange
 		const expectedOptions = 3;
-		const element = /radio-option/g;
+		const element = /type="radio"/g;
 		const props = {
 			control: {
 				label: 'FAKE LABEL',


### PR DESCRIPTION
## feat(validator): add validation support for `RadioGroup`
<!--
☝️ Put your PR title up here!

"scope" could be one of our apps or packages:
- form, validator, demo, landing-page, docs...

✨ Example PR titles:
    - feat(form): implement new FormControl isValid state
    - fix(validator): correct the variable name typo causing errors
    - style(landing-page): update the logo in the landing page app
    - docs: update content project CONTRIBUTING.md
-->

Fixes #230 <!-- 👈🏻 Put the issue number here! -->

Description of changes: <!-- 👇🏻 List the changes done! -->
- Added support for `RadioGroup` validation
    - Removed `<div>` element covering the `<input>` and `<label>` elements of `RadioGroup`. This was most likely interfering with validation.
    - Also added `<br>` elements for formatting purposes. Otherwise the radio buttons would be on the same line. Can remove if it's not necessary.

The first test is failing right now in `RadioGroup.astro.test.ts`, but I suspect it's due to the removal of the `<div>` element. It's not recognizing the radio options without it. I can fix this as well in the same PR, if required.

Tag a reviewer: @Icyscools @ayoayco 

Tasks:
- [x] I have ran the build command to make sure apps are working: `npm run build`
- [x] I have ran the tests to make sure nothing is broken: `npm run test`
- [x] I have ran the linter to make sure code is clean: `npm run lint`
- [x] I have reviewed my own code to remove changes that are not needed

<!-- THANK YOU FOR THE CONTRIBUTION! 🚀 -->